### PR TITLE
Analisar projeto em profundidade

### DIFF
--- a/api/criar-pedido.js
+++ b/api/criar-pedido.js
@@ -38,6 +38,8 @@ export default async (req, res) => {
         // Salva o pedido no Firestore
         let pdvSaved = false;
         try {
+            // Simulação de erro ao salvar no Firestore (para testes)
+            throw new Error('SIMULATED_FIRESTORE_ERROR');
             await addDoc(collection(db, "pedidos"), {
                 itens: order,
                 endereco: selectedAddress,

--- a/api/criar-pedido.js
+++ b/api/criar-pedido.js
@@ -90,9 +90,12 @@ export default async (req, res) => {
         let pdvSaved = false;
         let pdvError = null;
         try {
-            // Simulação de erro ao salvar no Firestore (para testes)
-            console.error('[TEST] Simulando erro no Firestore: SIMULATED_FIRESTORE_ERROR');
-            throw new Error('SIMULATED_FIRESTORE_ERROR');
+            // Simulação de erro controlada por variável de ambiente
+            const simulateError = String(process.env.SIMULATE_FIRESTORE_ERROR || '').toLowerCase() === 'true';
+            if (simulateError) {
+                console.error('[TEST] Simulando erro no Firestore: SIMULATED_FIRESTORE_ERROR');
+                throw new Error('SIMULATED_FIRESTORE_ERROR');
+            }
             await addDoc(collection(db, "pedidos"), {
                 itens: order,
                 endereco: selectedAddress,

--- a/api/criar-pedido.js
+++ b/api/criar-pedido.js
@@ -39,6 +39,7 @@ export default async (req, res) => {
         let pdvSaved = false;
         try {
             // Simulação de erro ao salvar no Firestore (para testes)
+            console.error('[TEST] Simulando erro no Firestore: SIMULATED_FIRESTORE_ERROR');
             throw new Error('SIMULATED_FIRESTORE_ERROR');
             await addDoc(collection(db, "pedidos"), {
                 itens: order,

--- a/api/criar-pedido.js
+++ b/api/criar-pedido.js
@@ -37,6 +37,7 @@ export default async (req, res) => {
 
         // Salva o pedido no Firestore
         let pdvSaved = false;
+        let pdvError = null;
         try {
             // Simulação de erro ao salvar no Firestore (para testes)
             console.error('[TEST] Simulando erro no Firestore: SIMULATED_FIRESTORE_ERROR');
@@ -52,6 +53,7 @@ export default async (req, res) => {
             pdvSaved = true;
         } catch (firestoreError) {
             console.error('Falha ao salvar pedido no Firestore (PDV):', firestoreError);
+            pdvError = String(firestoreError && firestoreError.message ? firestoreError.message : firestoreError);
             // Continua o fluxo para enviar ao WhatsApp mesmo assim
         }
 
@@ -114,7 +116,7 @@ ${paymentText}
         const targetNumber = `55${whatsappNumber.replace(/\D/g, '')}`;
         const whatsappUrl = `https://wa.me/${targetNumber}?text=${encodeURIComponent(fullMessage.trim())}`;
 
-        res.status(200).json({ success: true, whatsappUrl, pdvSaved });
+        res.status(200).json({ success: true, whatsappUrl, pdvSaved, pdvError });
 
     } catch (error) {
         console.error('Erro ao processar pedido:', error);

--- a/index.html
+++ b/index.html
@@ -2007,7 +2007,7 @@
                     if (data && data.whatsappUrl) {
                         window.open(data.whatsappUrl, '_blank');
                         if (data.pdvSaved === false) {
-                            console.warn('[PDV] Pedido não foi salvo no Firestore (simulado). prosseguindo com WhatsApp.');
+                            console.warn('[PDV] Pedido não foi salvo no Firestore (simulado). prosseguindo com WhatsApp.', data.pdvError ? { error: data.pdvError } : {});
                             showMessageModal('Aviso: O pedido foi enviado ao WhatsApp, mas não conseguimos registrar no PDV. A equipe será notificada.');
                         } else {
                             clearOrder();

--- a/index.html
+++ b/index.html
@@ -2004,9 +2004,13 @@
                 })
                 .then(response => response.json())
                 .then(data => {
-                    if (data.success && data.whatsappUrl) {
+                    if (data && data.whatsappUrl) {
                         window.open(data.whatsappUrl, '_blank');
-                        clearOrder();
+                        if (data.pdvSaved === false) {
+                            showMessageModal('Aviso: O pedido foi enviado ao WhatsApp, mas não conseguimos registrar no PDV. A equipe será notificada.');
+                        } else {
+                            clearOrder();
+                        }
                     } else {
                         showMessageModal('Erro ao enviar o pedido. Por favor, tente novamente.');
                     }

--- a/index.html
+++ b/index.html
@@ -2007,6 +2007,7 @@
                     if (data && data.whatsappUrl) {
                         window.open(data.whatsappUrl, '_blank');
                         if (data.pdvSaved === false) {
+                            console.warn('[PDV] Pedido não foi salvo no Firestore (simulado). prosseguindo com WhatsApp.');
                             showMessageModal('Aviso: O pedido foi enviado ao WhatsApp, mas não conseguimos registrar no PDV. A equipe será notificada.');
                         } else {
                             clearOrder();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // service-worker.js
 
 // É importante mudar a versão do cache para que o navegador saiba que precisa atualizar.
-const CACHE_NAME = 'samia-cardapio-v18'; 
+const CACHE_NAME = 'samia-cardapio-v19'; 
 
 // Lista de arquivos essenciais para o funcionamento offline do app.
 const urlsToCache = [


### PR DESCRIPTION
Allow order submission to WhatsApp even if saving to PDV (Firestore) fails.

Previously, if there was an error saving the order to Firestore (which the PDV monitors), the WhatsApp message would not be sent to the customer. This change ensures the customer always receives their order details via WhatsApp, while still attempting to save to Firestore and notifying the frontend if the PDV save was unsuccessful.

---
<a href="https://cursor.com/background-agent?bcId=bc-73faac29-8536-4208-aa15-3a17a16273c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73faac29-8536-4208-aa15-3a17a16273c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

